### PR TITLE
sqlsecrot GitHub workflow fixes

### DIFF
--- a/support/sqlsecretrotation/.github/workflows/workflow.bicep.sqlsecrot.yml
+++ b/support/sqlsecretrotation/.github/workflows/workflow.bicep.sqlsecrot.yml
@@ -19,7 +19,6 @@ defaults:
 jobs:
   deploy:
     name: "Deploy"
-    needs: preview
     runs-on: ubuntu-latest
 
     steps:

--- a/support/sqlsecretrotation/.github/workflows/workflow.bicep.sqlsecrot.yml
+++ b/support/sqlsecretrotation/.github/workflows/workflow.bicep.sqlsecrot.yml
@@ -6,7 +6,7 @@ on:
 
 # Set envs
 env:
-  WORKDIR: "iac/bicep"
+  WORKDIR: "support/sqlsecretrotation/iac/bicep"
   RESOURCES_SUFFIX: "sqlsecrot"
   # RESOURCES_PREFIX: "devopsoh44707" # hardcoded or dynamic based on repo name
   # LOCATION: "westus2" # hardcoded or get from secrets
@@ -35,14 +35,14 @@ jobs:
           script: return context.repo.repo.toLowerCase()
 
       # Concat RG name
-      - name: Get repo name
+      - name: Get resource group name
         uses: actions/github-script@v5
         id: resource_group_name
         with:
           result-encoding: string
           script: |
             const { RESOURCES_SUFFIX } = process.env
-            const repo_name = context.repo.repo.toLowerCase()
+            const repo_name = "${{ steps.resources_prefix.outputs.result }}"
             return `${repo_name}${RESOURCES_SUFFIX}rg`
 
       # Login to Azure with Service Principal
@@ -63,4 +63,4 @@ jobs:
             --name ${{ github.run_id }} \
             --resource-group ${{ steps.resource_group_name.outputs.result }} \
             --template-file ${{ env.WORKDIR }}/main.bicep \
-            --parameters keyVaultRgName='${{ env.RESOURCES_PREFIX }}rg' keyVaultName='${{ steps.resources_prefix.outputs.result }}kv' resourcesPrefix='${{ steps.resources_prefix.outputs.result }}' resourcesSuffix='${{ env.RESOURCES_SUFFIX }}'
+            --parameters keyVaultRgName='${{ steps.resources_prefix.outputs.result }}rg' keyVaultName='${{ steps.resources_prefix.outputs.result }}kv' resourcesPrefix='${{ steps.resources_prefix.outputs.result }}' resourcesSuffix='${{ env.RESOURCES_SUFFIX }}'


### PR DESCRIPTION
Changing the GH workflow for secret rotation infra deployment to work standalone.

* Removed dependency on `preview` stage which doesn't exist
* Changed `WORKDIR` to point to the sqlsecretrotation folder
* Fixed KeyVault resource group name parameter