### PR TITLE
Fix typo

### DIFF
--- a/iac/bicep/appService.bicep
+++ b/iac/bicep/appService.bicep
@@ -75,7 +75,7 @@ resource appServiceTripviewer 'Microsoft.Web/sites@2020-12-01' = {
         }
         {
           name: 'STAGING_USER_ROOT_URL'
-          value: 'https://${appServiceApiPoiStaging.properties.defaultHostName}'
+          value: 'https://${appServiceApiUserprofileStaging.properties.defaultHostName}'
         }
         {
           name: 'STAGING_USER_JAVA_ROOT_URL'


### PR DESCRIPTION
# PR Template

## Purpose

Making a minor fix to a typo in the bicep that addresses a broken link in the trip viewer health check GUI.  Previously the link was pointing to a broken URL where "user profile" in staging was not going anywhere.

- ...

## Does this introduce a breaking change?

```text
[ ] Yes
[ X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```text
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Run Bicep deployment
- See broken link on the Trip Viewer WebApp for `User Profile Staging Health Check`
- After the fix, the link should work

## What to Check

Verify that the following are valid

- link

## Other Information

N/A
